### PR TITLE
use string instead of index for serializing constraint enum

### DIFF
--- a/android/src/main/java/dev/thinkng/flt_worker/internal/WorkRequests.java
+++ b/android/src/main/java/dev/thinkng/flt_worker/internal/WorkRequests.java
@@ -146,7 +146,7 @@ final class WorkRequests {
 
     if (constraintsJson.get("networkType") != null) {
       builder.setRequiredNetworkType(
-          NetworkType.values()[(Integer) constraintsJson.get("networkType")]);
+          NetworkType.valueOf((String) constraintsJson.get("networkType")));
     }
     if (constraintsJson.get("batteryNotLow") != null) {
       builder.setRequiresBatteryNotLow((Boolean) constraintsJson.get("batteryNotLow"));

--- a/android/src/test/java/dev/thinkng/flt_worker/internal/WorkRequestsTest.java
+++ b/android/src/test/java/dev/thinkng/flt_worker/internal/WorkRequestsTest.java
@@ -93,7 +93,7 @@ public class WorkRequestsTest {
   @Test
   public void parseConstraints() {
     Map<String, Object> constraintsJson = new HashMap<>();
-    constraintsJson.put("networkType", NetworkType.NOT_ROAMING.ordinal());
+    constraintsJson.put("networkType", NetworkType.NOT_ROAMING.toString());
     constraintsJson.put("batteryNotLow", true);
     constraintsJson.put("charging", null);
     constraintsJson.put("deviceIdle", true);

--- a/lib/src/constraints.dart
+++ b/lib/src/constraints.dart
@@ -50,7 +50,7 @@ class WorkConstraints {
 
   /// Serializes this constraints into a json object.
   Map<String, dynamic> toJson() => {
-    'networkType': networkType?.index,
+    'networkType': networkType == null ? null : _enumToSnakeCaseString(networkType),
     'batteryNotLow': batteryNotLow,
     'charging': charging,
     'deviceIdle': deviceIdle,
@@ -75,3 +75,10 @@ enum NetworkType {
   /// An unmetered network connection is required for this work.
   unmetered,
 }
+
+String _enumToSnakeCaseString(NetworkType networkType) => networkType
+    .toString()
+    .split('.')
+    .last
+    .replaceAllMapped(RegExp(r'(?<=[a-z])[A-Z]'), (m) => ('_' + m.group(0)))
+    .toUpperCase();


### PR DESCRIPTION
This fixes a bug where the wrong `NetworkType` was used. This is because the `NetworkType` enum apparently has a different order in code than in the docs.